### PR TITLE
feat: Searchable Dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wally.lock
 
 .vscode/*.d.luau
 Assets/Fonts/Touche
+.DS_Store

--- a/Src/Elements/Dropdown.luau
+++ b/Src/Elements/Dropdown.luau
@@ -29,6 +29,9 @@ function Element:New(Idx, Config)
 		Value = Config.Default or Config.Value,
 		Multi = Config.Multi or false,
 		AutoDeselect = Config.AutoDeselect or false,
+		Searchable = Config.Searchable or false,
+		FocusSearch = Config.FocusSearch or true,
+		SearchPlaceholder = Config.SearchPlaceholder or "Search...",
 		Displayer = Config.Displayer or function(Value)
 			return typeof(Value) ~= "number" and tostring(Library.Utilities:Prettify(Value)) or Value
 		end,
@@ -102,8 +105,8 @@ function Element:New(Idx, Config)
 	})
 
 	local DropdownScrollFrame = New("ScrollingFrame", {
-		Size = UDim2.new(1, -5, 1, -10),
-		Position = UDim2.fromOffset(5, 5),
+		Size = UDim2.new(1, -5, 1, Dropdown.Searchable and -40 or -10),
+		Position = UDim2.fromOffset(5, Dropdown.Searchable and 40 or 5),
 		BackgroundTransparency = 1,
 		BottomImage = "rbxassetid://6889812791",
 		MidImage = "rbxassetid://6889812721",
@@ -144,6 +147,16 @@ function Element:New(Idx, Config)
 			ImageTransparency = 0.1,
 		}),
 	}) :: Frame
+
+	local SearchableTextbox = require(Components.Textbox)(DropdownHolderFrame, true)
+	SearchableTextbox.Frame.Visible = Dropdown.Searchable
+	SearchableTextbox.Frame.AnchorPoint = Vector2.new(0.5, 0)
+	SearchableTextbox.Frame.Position = UDim2.new(0.5, 0, 0, 5)
+	SearchableTextbox.Frame.Size = UDim2.new(1, -5, 0, 32)
+	SearchableTextbox.Input.PlaceholderText = Dropdown.SearchPlaceholder
+	SearchableTextbox.Input.Text = ""
+
+	local SearchBox = SearchableTextbox.Input
 
 	local ButtonSelector_BuildList = New("Frame", {
 		Size = UDim2.fromOffset(4, 14),
@@ -219,21 +232,25 @@ function Element:New(Idx, Config)
 
 	local ListSizeX = 0
 	local function RecalculateListSize()
-		if #Dropdown.Values > 10 then
-			DropdownHolderCanvas.Size = UDim2.fromOffset(ListSizeX, 392)
-		else
-			DropdownHolderCanvas.Size = UDim2.fromOffset(ListSizeX, DropdownListLayout.AbsoluteContentSize.Y + 10)
-		end
+		local Subtract = Dropdown.Searchable and 42 or 0
+		local Add = (Dropdown.Searchable and SearchBox.Text ~= "") and 35 or 0
+
+		DropdownHolderCanvas.Size = UDim2.fromOffset(ListSizeX, math.min(392 - Subtract, DropdownListLayout.AbsoluteContentSize.Y + 10 + Add))
 	end
 
 	local function RecalculateCanvasSize()
 		DropdownScrollFrame.CanvasSize = UDim2.fromOffset(0, DropdownListLayout.AbsoluteContentSize.Y)
 	end
 
+	local function RepopulateDropdownList()
+		Dropdown:BuildDropdownList()
+	end
+
 	RecalculateListPosition()
 	RecalculateListSize()
 
 	Creator.AddSignal(DropdownInner:GetPropertyChangedSignal("AbsolutePosition"), RecalculateListPosition)
+	Creator.AddSignal(SearchBox:GetPropertyChangedSignal("Text"), RepopulateDropdownList)
 
 	local ScrollFrame = self.ScrollFrame
 	function Dropdown:Open()
@@ -246,6 +263,14 @@ function Element:New(Idx, Config)
 			Enum.EasingStyle.Quart,
 			.2
 		)
+
+		if Dropdown.Searchable then
+			SearchBox.Text = ""
+			
+			if Dropdown.FocusSearch then
+				SearchBox:CaptureFocus()
+			end
+		end
 	end
 
 	function Dropdown:Close()
@@ -253,6 +278,11 @@ function Element:New(Idx, Config)
 		ScrollFrame.ScrollingEnabled = true
 		DropdownHolderFrame.Size = UDim2.fromScale(1, 0.6)
 		DropdownHolderCanvas.Visible = false
+
+		if Dropdown.Searchable then
+			SearchBox.Text = ""
+			SearchBox:ReleaseFocus()
+		end
 	end
 
 	Creator.AddSignal(DropdownInner.MouseButton1Click, function()
@@ -321,10 +351,18 @@ function Element:New(Idx, Config)
 		local Count = 0
 
 		for Idx, Value in next, Values do
+			Count += 1
+
+			if Count % 30 == 0 then
+				task.wait()
+			end
+
+			if Dropdown.Searchable and SearchBox.Text ~= "" and not string.lower(Dropdown.Displayer(Value)):match(string.lower(SearchBox.Text)) then
+				continue
+			end
+
 			local Table = {}
 			local Selected
-
-			Count += 1
 
 			local Button = Button_BuildList:Clone()
 			local ButtonSelector, ButtonLabel = Button.Frame, Button.ButtonLabel
@@ -431,10 +469,6 @@ function Element:New(Idx, Config)
 			Dropdown:Display()
 
 			Buttons[Button] = Table
-
-			if Count % 30 == 0 then
-				task.wait()
-			end
 		end
 
 		ListSizeX = 0


### PR DESCRIPTION
This PR adds Searchable Dropdowns to Fluent.

Demo:

https://github.com/user-attachments/assets/9caa543e-8fb5-4f32-a4dc-d81ef4cd2acd

Documentation:
```lua
local Dropdown = Tabs.Main:CreateDropdown("Dropdown", {
    Title = "Dropdown",
    Values = {"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen"},
    Multi = false,
    Searchable = true, -- Its false by default
    FocusSearch = true, -- Focuses the searchbar on dropdown menu click, default is true
    SearchPlaceholder = "Search...", -- Changes the placeholder text inside the searchbar, default is "Search..."
    Default = 1,
})
```

NOTE:
I did not implement `:SetSearchable()` or `:SetSearchPlaceholder()`